### PR TITLE
fix: Fixed a bug that usePagination retrieves old data

### DIFF
--- a/packages/core/src/hooks/__tests__/usePagination.mock.ts
+++ b/packages/core/src/hooks/__tests__/usePagination.mock.ts
@@ -246,3 +246,80 @@ export const paginationQueryWithKeywordDocument = gql`
 `;
 
 export const paginationQueryWithKeywordMockData = forwardPaginationQueryMockData;
+
+export type NodeQueryDataType = {
+  node: {
+    id: string;
+    __typename: 'User';
+    items: ItemsConnectionType;
+  };
+};
+
+export const nodeFirstQueryDocument = gql`
+  query TestQuery($id: String, $count: Int, $cursor: String) {
+    node(id: $id) {
+      id
+      __typename
+      items(first: $count, after: $cursor) {
+        edges {
+          node {
+            id
+            __typename
+          }
+          cursor
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+export const nodeFirstQueryMockData = {
+  node: {
+    id: userId,
+    __typename: 'User',
+    items: {
+      edges: [
+        { node: { id: item1Id, __typename: 'Item' }, cursor: 'cursor-1' },
+        { node: { id: item2Id, __typename: 'Item' }, cursor: 'cursor-2' },
+      ],
+      pageInfo: { hasNextPage: true, endCursor: 'cursor-2' },
+    },
+  },
+};
+
+export const nodePaginationQueryDocument = gql`
+  query TestQuery($id: String, $count: Int, $cursor: String) {
+    node(id: $id) {
+      id
+      __typename
+      items(first: $count, after: $cursor) {
+        edges {
+          node {
+            id
+            __typename
+          }
+          cursor
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+export const nodePaginationQueryMockData = {
+  node: {
+    id: userId,
+    __typename: 'User',
+    items: {
+      edges: [{ node: { id: item3Id, __typename: 'Item' }, cursor: 'cursor-3' }],
+      pageInfo: { hasNextPage: false, endCursor: 'cursor-3' },
+    },
+  },
+};

--- a/packages/core/src/hooks/usePagination.ts
+++ b/packages/core/src/hooks/usePagination.ts
@@ -55,7 +55,7 @@ export const usePagination = <TNode, TData = unknown, TVariables = OperationVari
     if (called && fetchMore) {
       void fetchMore({ variables: allVariables as TVariables });
     } else {
-      void call({ variables: allVariables as TVariables });
+      void call({ variables: allVariables as TVariables, fetchPolicy: 'network-only', nextFetchPolicy: 'cache-first' });
     }
   };
 


### PR DESCRIPTION
When using a Query that retrieves data using `node()`, Nau retrieved the current page data instead of the next page due to a cache.